### PR TITLE
Update cloud-hasher-stack.ts

### DIFF
--- a/lib/cloud-hasher-stack.ts
+++ b/lib/cloud-hasher-stack.ts
@@ -14,7 +14,7 @@ export class CloudHasherStack extends Stack {
     });
 
     const hashRequestLambda = new Function(this, 'CloudHasherLambda', {
-      runtime: Runtime.GO_1_X,
+      runtime: Runtime.PROVIDED_AL2,
       handler: 'main',
       deadLetterQueue: dlq,
       deadLetterQueueEnabled: true,


### PR DESCRIPTION
### Description

Update the Go runtime since _GO_1_X is deprecated.
For more information : 

https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html